### PR TITLE
Support FileStorage ids with spaces

### DIFF
--- a/LiteDB/Storage/LiteFileInfo.cs
+++ b/LiteDB/Storage/LiteFileInfo.cs
@@ -13,7 +13,7 @@ namespace LiteDB
         /// <summary>
         /// File id have a specific format - it's like file path.
         /// </summary>
-        public const string ID_PATTERN = @"^[\w-$@!+%;\.]+(\/[\w-$@!+%;\.]+)*$";
+        public const string ID_PATTERN = @"^[\w-$@!+%;\. ]+(\/[\w-$@!+%;\. ]+)*$";
 
         private static Regex IdPattern = new Regex(ID_PATTERN, RegexOptions.Compiled);
 


### PR DESCRIPTION
This allows better support for using the the path as the id. Otherwise, if an id has a space an InvalidFormat exception will be thrown.